### PR TITLE
Fix cell options

### DIFF
--- a/quarto.qmd
+++ b/quarto.qmd
@@ -40,7 +40,10 @@ round_numeric_variables <- function(data, digits = 0) {
 }
 ```
 
-```{r, eval=FALSE, include=FALSE}
+```{r}
+#| eval: FALSE
+#| include: FALSE
+
 callr::rscript("data-raw.R")
 ```
 
@@ -84,7 +87,9 @@ cars_skim <-
 
 ## Visualization
 
-```{r figure, message=FALSE}
+```{r figure}
+#| message=FALSE
+
 pl1 <- ggplot(cars, aes(
   x = hp,
   y = mpg,


### PR DESCRIPTION
Use '#|' for Quarto cell options instead of RMarkdown format.

see Quarto · [Execution Options](https://quarto.org/docs/computations/execution-options.html#output-options)