### PR TITLE
Fix cross-references in docs

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -4,8 +4,8 @@
   "default": true,
   // Allow duplication for headings with different parents
   "MD024": {
-    "siblings_only": true
-  }
+    "siblings_only": true,
+  },
   // Disable rules in file: <!-- markdownlint-disable -->
   // Enable rules in file:  <!-- markdownlint-enable -->
 }

--- a/README.md
+++ b/README.md
@@ -8,17 +8,21 @@ callr::rscript("utils/run-all.R", stdout="utils/run-all.log")  # R console
 
 ```sh
 Rscript utils/run-all.R > "utils/run-all.log"  # terminal (local)
-```
 
-```sh
-./utils/run-all-docker.sh  # terminal (Docker)
+./utils/run-all-docker.sh                      # terminal (Docker)
 ```
 
 ## Install · ⚙️
 
 ### Local · 💻
 
-Install all R packages project with `utils/r-packages-update.R`
+Install, sync, update project R packages from `pkg.lock`:
+
+```sh
+Rscript utils/r-packages-install.R
+
+Rscript utils/r-packages-update.R
+```
 
 ### Codespace · 🛰️
 
@@ -30,22 +34,15 @@ Run in [Github Codespaces](https://docs.github.com/en/codespaces/getting-started
 
 ### Docker · 🚢
 
-Use [Docker](https://docs.docker.com/get-docker/) to run RStudio in a browser with all dependencies.
+Use [Docker](https://docs.docker.com/get-docker/) to run RStudio in a browser
+with all dependencies.
 
 <http://localhost:8787/>
 
 ```sh
 docker-compose up -d  # start container in detached mode
 
-docker-compose down  # shut down container
-```
-
-## How-to · 💡
-
-Update R packages with latest R version in a Rocker container
-
-```sh
-./utils/update-rocker.sh
+docker-compose down   # shut down container
 ```
 
 ## License · ⚖️

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -40,11 +40,11 @@ round_numeric_variables <- function(data, digits = 0) {
 }
 ```
 
-```{r data-raw}
+```{r run-data-script}
 #| eval: FALSE
 #| include: FALSE
 
-callr::rscript("data-raw.R")
+callr::rscript("data.R")
 ```
 
 ---

--- a/r-guide/how-to.qmd
+++ b/r-guide/how-to.qmd
@@ -36,10 +36,12 @@ purrr::map(fs::dir_ls(".", glob = "*.Rmd"), rmarkdown::render)
 
 Use script and save output
 
+Run these commands from the repository root (not from `r-guide/`).
+
 ```R
-callr::rscript("z-run-all.R", stdout="z-run-all.log")  # R console
+callr::rscript("utils/run-all.R", stdout="utils/run-all.log")  # R console
 ```
 
 ```sh
-Rscript z-run-all.R > "z-run-all.log"                  # terminal
+Rscript utils/run-all.R > "utils/run-all.log"                  # terminal
 ```

--- a/r-guide/style-guide.qmd
+++ b/r-guide/style-guide.qmd
@@ -18,8 +18,8 @@ pipes — `|>` · 🌬️
 
 data · 🔢
 
-+ use coherent prefixes for groups of data // `dt dt_ctry dt_ctz`
-+ prefix `raw_` for raw data read into object with
++ use coherent prefixes for groups of data // `dt_ctry`
++ prefix `raw_` for raw data from source // `raw_dt_ctry`
 
 plots · 📊
 


### PR DESCRIPTION
Revise docs to keep references and workflow guidance consistent.

- align internal links
- standardize Docker commands
- remove stale 'data-raw' references

_Created with GPT-5.3-Codex_
